### PR TITLE
Differentiates licenses between Codice-only and Codice+progenitors of the library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.ProfileStorage.defaultProfile
 
@@ -31,7 +39,17 @@ allprojects {
         }
         kotlin {
             ktlint()
-            licenseHeaderFile(rootProject.file("codice.license.kt"), "(package|// Default package)")
+            if (project.name == "usng2-common") {
+                licenseHeaderFile(rootProject.file("progenitor.license.kt"))
+            } else {
+                licenseHeaderFile(rootProject.file("codice.license.kt"), "(package|// Default package)")
+            }
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
+        kotlinGradle {
+            ktlint()
+            licenseHeaderFile(rootProject.file("codice.license.kt"), "// Build file")
             trimTrailingWhitespace()
             endWithNewline()
         }
@@ -42,7 +60,6 @@ tasks {
     "build" {
         dependsOn("detektCheck")
     }
-
 }
 
 configure<DetektExtension> {

--- a/codice.license.kt
+++ b/codice.license.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              $YEAR Codice Foundation
+Copyright (c) $YEAR Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/js-test/build.gradle.kts
+++ b/js-test/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 plugins {
     id("com.moowork.grunt") version "1.2.0"
     id("com.moowork.node") version "1.2.0"

--- a/progenitor.license.kt
+++ b/progenitor.license.kt
@@ -1,0 +1,10 @@
+/*
+Copyright (c) 2009 Larry Moore, larmoor@gmail.com
+              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
+                   Calvin Metcalf (proj4js)
+              2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 pluginManagement {
     resolutionStrategy {
         eachPlugin {

--- a/usng2-common/build.gradle.kts
+++ b/usng2-common/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 plugins {
     id("kotlin-platform-common") version "1.2.51"
 }

--- a/usng2-js/build.gradle.kts
+++ b/usng2-js/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 import com.moowork.gradle.node.npm.NpmTask
 import org.jetbrains.kotlin.gradle.frontend.KotlinFrontendExtension
 import org.jetbrains.kotlin.gradle.frontend.webpack.WebPackExtension
@@ -66,7 +74,7 @@ tasks {
     }
 }
 
-open class NpmPrePublish: DefaultTask() {
+open class NpmPrePublish : DefaultTask() {
     @TaskAction
     fun run() {
         val outDir = project.mkdir("${project.buildDir}/npmpub_tmp")

--- a/usng2-js/src/main/kotlin/BoundingBox.kt
+++ b/usng2-js/src/main/kotlin/BoundingBox.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              2018 Codice Foundation
+Copyright (c) 2018 Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/usng2-js/src/main/kotlin/Converter.kt
+++ b/usng2-js/src/main/kotlin/Converter.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              2018 Codice Foundation
+Copyright (c) 2018 Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/usng2-js/src/main/kotlin/LatLon.kt
+++ b/usng2-js/src/main/kotlin/LatLon.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              2018 Codice Foundation
+Copyright (c) 2018 Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/usng2-js/src/main/kotlin/Usng.kt
+++ b/usng2-js/src/main/kotlin/Usng.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              2018 Codice Foundation
+Copyright (c) 2018 Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/usng2-js/src/main/kotlin/Utm.kt
+++ b/usng2-js/src/main/kotlin/Utm.kt
@@ -1,8 +1,5 @@
 /*
-Copyright (c) 2009 Larry Moore, larmoor@gmail.com
-              2014 Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and
-                   Calvin Metcalf (proj4js)
-              2018 Codice Foundation
+Copyright (c) 2018 Codice Foundation
 
 Released under The MIT License; see
 http://www.opensource.org/licenses/mit-license.php

--- a/usng2-jvm/build.gradle.kts
+++ b/usng2-jvm/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under The MIT License; see
+http://www.opensource.org/licenses/mit-license.php
+or http://en.wikipedia.org/wiki/MIT_License
+*/
+// Build file
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -26,7 +34,6 @@ tasks {
         }
     }
     val sourceCompatibility = "1.8"
-
 
     "build" {
         dependsOn("publishToMavenLocal")
@@ -70,4 +77,3 @@ publishing {
         }
     }
 }
-


### PR DESCRIPTION
Also adds license headers to build files.