### PR TITLE
Upgrades kotlin to 1.2.60 and moves detektCheck to the check phase.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ allprojects {
     apply(plugin = "com.diffplug.gradle.spotless")
     apply(plugin = "net.ltgt.errorprone")
 
+    dependencies {
+        errorprone(Libs.googleErrorProne)
+    }
+
     repositories {
         jcenter()
         mavenLocal()
@@ -52,7 +56,7 @@ allprojects {
 }
 
 tasks {
-    "build" {
+    "check" {
         dependsOn("detektCheck")
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,10 +13,11 @@ object Versions {
 
     const val javaTarget = "1.8"
 
-    const val kotlin = "1.2.51"
+    const val kotlin = "1.2.60"
     const val kotlinFrontendPlugin = "0.0.33"
     const val spotless = "3.10.0"
     const val errorprone = "0.0.16"
+    const val googleErrorProne = "2.3.1"
     const val testLogger = "1.4.0"
     const val detekt = "1.0.0.RC8"
     const val mooworkGrunt = "1.2.0"
@@ -40,4 +41,6 @@ object Libs {
     const val kotlinFrontendPlugin = "org.jetbrains.kotlin:kotlin-frontend-plugin:${Versions.kotlinFrontendPlugin}"
     const val mooworkNode = "com.moowork.gradle:gradle-node-plugin:${Versions.mooworkNode}"
     const val junit = "junit:junit:${Versions.junit}"
+
+    const val googleErrorProne = "com.google.errorprone:error_prone_core:${Versions.googleErrorProne}"
 }

--- a/js-test/build.gradle.kts
+++ b/js-test/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
     id("com.moowork.node").version(Versions.mooworkNode)
 }
 
+node {
+    download = true
+}
+
 tasks {
     "installGrunt" {
         dependsOn(":usng2-js:build", "npmInstall")


### PR DESCRIPTION
#### What does this PR do (if it's not clear from the Title)? Please include any specification references that apply.

#### Checklist:
- [ ] Common Kotlin Unit Tests Added/Modified
- [ ] Javascript Mocha Tests Added to `js-test` module