### PR TITLE
Added Jenkinsfiles for PR build and deploying

### DIFF
--- a/DeployJenkinsfile
+++ b/DeployJenkinsfile
@@ -1,0 +1,49 @@
+//"Jenkins Pipeline is a suite of plugins which supports implementing and integrating continuous delivery pipelines into Jenkins. Pipeline provides an extensible set of tools for modeling delivery pipelines "as code" via the Pipeline DSL."
+//More information can be found on the Jenkins Documentation page https://jenkins.io/doc/
+pipeline {
+    agent { label 'linux-docker-small' }
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'25'))
+        disableConcurrentBuilds()
+        timestamps()
+    }
+    triggers {
+        /*
+          Restrict nightly builds to master branch
+          Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
+        */
+        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
+    }
+    environment {
+        LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
+        PATH="${tool 'docker-latest'}/bin:${tool 'gradle-4.9'}/bin:$PATH"
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                slackSend channel: '#cx-bots-testing', tokenCredentialId: 'slack-connexta-cx-bots-testing', color: 'good', message: "STARTED: ${JOB_NAME} ${BUILD_NUMBER} ${BUILD_URL}"
+            }
+        }
+        stage('Full Build') {
+            steps {
+                sh './gradlew clean check'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh './gradlew publish'
+            }
+        }
+    }
+    post {
+        success {
+            slackSend channel: '##cx-bots-testing', tokenCredentialId: 'slack-connexta-cx-bots-testing', color: 'good', message: "SUCCESS: ${JOB_NAME} ${BUILD_NUMBER}"
+        }
+        failure {
+            slackSend channel: '##cx-bots-testing', tokenCredentialId: 'slack-connexta-cx-bots-testing', color: '#ea0017', message: "FAILURE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+        unstable {
+            slackSend channel: '##cx-bots-testing', tokenCredentialId: 'slack-connexta-cx-bots-testing', color: '#ffb600', message: "UNSTABLE: ${JOB_NAME} ${BUILD_NUMBER}. See the results here: ${BUILD_URL}"
+        }
+    }
+}

--- a/PrTestJenkinsfile
+++ b/PrTestJenkinsfile
@@ -1,0 +1,54 @@
+//"Jenkins Pipeline is a suite of plugins which supports implementing and integrating continuous delivery pipelines into Jenkins. Pipeline provides an extensible set of tools for modeling delivery pipelines "as code" via the Pipeline DSL."
+//More information can be found on the Jenkins Documentation page https://jenkins.io/doc/
+library 'github-commenter-shared-library@master'
+
+pipeline {
+    agent { label 'linux-docker-small' }
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'25'))
+        disableConcurrentBuilds()
+        timestamps()
+    }
+    triggers {
+        /*
+          Restrict nightly builds to master branch
+          Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
+        */
+        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
+    }
+    environment {
+        LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
+        PATH="${tool 'docker-latest'}/bin:${tool 'gradle-4.9'}/bin:$PATH"
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                withCredentials([usernameColonPassword(credentialsId: '	cxbot-github-auth', variable: 'GITHUB_TOKEN')]) {
+                    postCommentIfPR("Internal build has been started. Your results will be available at completion. See build progress in [Jenkins UI](${BUILD_URL}) or in [Blue Ocean UI](${BUILD_URL}display/redirect).", 'codice', 'usng2', "${GITHUB_TOKEN}")
+                }
+            }
+        }
+        stage('usng2 build') {
+            steps {
+                sh './gradlew clean check'
+            }
+        }
+    }
+    post {
+        success {
+            withCredentials([usernameColonPassword(credentialsId: '	cxbot-github-auth', variable: 'GITHUB_TOKEN')]) {
+                postCommentIfPR("Build success! See the job results in [Jenkins UI](${BUILD_URL}) or in [Blue Ocean UI](${BUILD_URL}display/redirect).", 'codice', 'usng2', "${GITHUB_TOKEN}")
+            }
+        }
+        failure {
+            withCredentials([usernameColonPassword(credentialsId: '	cxbot-github-auth', variable: 'GITHUB_TOKEN')]) {
+                postCommentIfPR("Build failure. See the job results in [Jenkins UI](${BUILD_URL}) or in [Blue Ocean UI](${BUILD_URL}display/redirect).", 'codice', 'usng2', "${GITHUB_TOKEN}")
+            }
+        }
+        unstable {
+            withCredentials([usernameColonPassword(credentialsId: '	cxbot-github-auth', variable: 'GITHUB_TOKEN')]) {
+                postCommentIfPR("Build unstable. See the job results in [Jenkins UI](${BUILD_URL}) or in [Blue Ocean UI](${BUILD_URL}display/redirect).", 'codice', 'usng2', "${GITHUB_TOKEN}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change
Added `Jenkinsfile`s for PR builds and Deploying.

### Alternate Designs
Travis CI was considered instead of Jenkins but can only be set up and maintained by organization owners.

### Benefits
It will allow PR builds before merging and an easier deployment process.

### Possible Drawbacks
There will be no side-effects or negative impacts.

### Verification Process
Built and run tests.

### Checklist:
- [ ] Common Kotlin Unit Tests Added/Modified
- [ ] Javascript Mocha Tests Added to `js-test` module

### Applicable Issues
N/A